### PR TITLE
Plot with json trt

### DIFF
--- a/library/meso.py
+++ b/library/meso.py
@@ -204,6 +204,14 @@ def tower(rotation, areas, radar, shear, time, path):
     print(n)
     headers=variables.rot_df().columns
     towers=pd.DataFrame(data=0.0, index=n, columns=headers)
+
+    # Set default value for radar range
+    towers['A_range'] = 999
+    towers['D_range'] = 999
+    towers['L_range'] = 999
+    towers['P_range'] = 999
+    towers['W_range'] = 999
+
     ## Build rotation tower per thunderstorm ID
     for ID in n:
         obj=prop.where(prop["v_ID"]==ID).dropna()

--- a/realtime_parallel.py
+++ b/realtime_parallel.py
@@ -246,8 +246,7 @@ def radel_processor (rotation_pos, rotation_neg, rels, radar, cartesian, path, s
           rotation_pos["shear_ID"].append(rotation_pos1["shear_ID"])
           rotation_neg["shear_ID"].append(rotation_neg1["shear_ID"])
 
-
-    return_dict[el]= rotation_pos, rotation_neg
+      return_dict[el]= rotation_pos, rotation_neg
   
   
   

--- a/realtime_plot.py
+++ b/realtime_plot.py
@@ -21,7 +21,6 @@ args = parser.parse_args()
 import sys
 sys.path.append(args.codedir)
 import os
-os.environ['METRANETLIB_PATH'] = '/srn/las/idl/lib/radlib/'
 import pandas as pd
 import skimage.morphology as skim
 pd.options.mode.chained_assignment = None
@@ -38,6 +37,10 @@ import pyart
 import library.variables as variables
 import library.plot as plot
 import library.io as io
+
+if not 'METRANETLIB_PATH' in os.environ:
+    os.environ['METRANETLIB_PATH'] = '/srn/las/idl/lib/radlib/'
+
 #%% Main function
 def main():
     #import variables

--- a/realtime_plot.py
+++ b/realtime_plot.py
@@ -102,8 +102,6 @@ def main():
         with open(pfile) as f: gj = FeatureCollection(gs.load(f))
         vert_p=pd.concat((vert_p,gpd.GeoDataFrame.from_features(gj['features'])),axis=0)#vert_p.append(gpd.GeoDataFrame.from_features(gj['features']))
     print(vert_p); print(vert_n); print(trtcells)
-    #%%read TRT file of timestep, use to cut out precipitation data -> displayed in background
-    cells,timelist=io.get_TRT(time, path)
     try:
       b_file=glob.glob(path["lomdata"]+'CZC/*'+str(time)+'*')[0]
       print(b_file)
@@ -117,16 +115,7 @@ def main():
       background=copy.deepcopy(czc)
       background[background<0]=np.nan
     except:
-      b_file=glob.glob(path["lomdata"]+'CZC/*'+str(time)+'*')[0]
-      print('Problem with file',b_file)
-      newcells=skim.dilation(cells[0],footprint=np.ones([5,5]))
-      newcells[newcells==0]=np.nan
-      newcells[newcells>0]=1
-      background=newcells
-    #if generation of background fails, is generated empty
-    # else:
-    #   background=np.zeros([640,710])
-    #   background[:]=np.nan
+      background = np.full((640,710), np.nan)
     #%% generate plot
     imtitle='Detected mesocyclones on VIL background';savepath=path["outdir"]+'IM/';imname='ROT'+str(time+'.png')
     plot.plot_cart_hist(time,background,trtcells,vert_p,vert_n, imtitle, savepath, imname, radar)


### PR DESCRIPTION
Dear Monika,

There is a routine in the realtime_plot using cell contours from ASCII TRT data whenever the CZC file for the background is not found. However, this routine doesn't seem to produce anything else than a simple transparent background. Since ASCII TRT files are not produced anymore at MCH, I simply removed this functionality, and implemented manually the transparent background.
Is it ok like this or do we need to keep this functionality, by making the function `get_TRT()` compatible with json TRT files?

I also made a minor modification allowing the METRANETLIB_PATH to be pre-specified as a Linux env variable, in case it is different from the hardcoded path (typical case: implementation in the LabVM)